### PR TITLE
Backbone extensions

### DIFF
--- a/js/main.js
+++ b/js/main.js
@@ -48,6 +48,7 @@ require.config({
         underscore:'libs/underscore',
         'underscore.string':'libs/underscore.string',
         backbone:'libs/backbone',
+        'resthub-backbone':'resthub/backbone.ext',
         localstorage:'libs/localstorage',
         text:'libs/text',
         i18n:'libs/i18n',

--- a/js/main.js
+++ b/js/main.js
@@ -62,11 +62,10 @@ require.config({
         'backbone-paginator':'libs/backbone.paginator',
         async:'libs/async.js',
         keymaster:'libs/keymaster',
-        hbs: 'resthub/handlebars-require'
+        hbs:'resthub/handlebars-require'
     }
 });
 
-// Preload main libs
 require(['router'], function (Router) {
 
     Router.initialize();

--- a/js/resthub/backbone.ext.js
+++ b/js/resthub/backbone.ext.js
@@ -8,6 +8,7 @@ define(['underscore', 'backbone', 'pubsub', 'resthub/jquery-event-destroyed'], f
     var originalUndelegateEvents = originalPrototype.undelegateEvents;
     var originalSetElement = originalPrototype.setElement;
     var originalRemove = originalPrototype.remove;
+    var originalDispose = originalPrototype.dispose;
     var originalConstructor = Backbone.View;
     var originalExtend = Backbone.View.extend;
 
@@ -77,6 +78,18 @@ define(['underscore', 'backbone', 'pubsub', 'resthub/jquery-event-destroyed'], f
         remove:function () {
             this.$el.off("destroyed");
             return originalRemove.call(this);
+        },
+
+        // Override Backbone dispose method to unbind Backbone Validation
+        // Bindings if defined
+        dispose:function () {
+            originalDispose.call(this);
+
+            if (Backbone.Validation) {
+                Backbone.Validation.unbind(this)
+            }
+
+            return this;
         }
 
     });

--- a/js/resthub/backbone.ext.js
+++ b/js/resthub/backbone.ext.js
@@ -77,7 +77,12 @@ define(['underscore', 'backbone', 'pubsub', 'resthub/jquery-event-destroyed'], f
         // after remove : this prevents dispose to be called twice
         remove:function () {
             this.$el.off("destroyed");
-            return originalRemove.call(this);
+            originalRemove.call(this);
+            var self = this;
+            // call backbone dispose method on el DOM removing
+            this.$el.on("destroyed", function () {
+                self.dispose();
+            });
         },
 
         // Override Backbone dispose method to unbind Backbone Validation

--- a/js/resthub/backbone.ext.js
+++ b/js/resthub/backbone.ext.js
@@ -95,6 +95,26 @@ define(['underscore', 'backbone', 'pubsub', 'resthub/jquery-event-destroyed'], f
             }
 
             return this;
+        },
+
+        // utility method providing a default and basic handler that
+        // populate model from a form input
+        refreshModel:function (form, model) {
+            var attributes = {};
+
+            form = form || this.$el.find("form");
+            form = form instanceof Backbone.$ ? form : this.$el.find((Backbone.$(form)));
+            form = form.find("input[type!='submit']");
+
+            if (arguments.length < 2) model = this.model;
+
+            // build array of form attributes to refresh model
+            form.each(_.bind(function (index, value) {
+                attributes[value.name] = value.value;
+                if (model) {
+                    model.set(value.name, value.value);
+                }
+            }, this));
         }
 
     });

--- a/js/resthub/backbone.ext.js
+++ b/js/resthub/backbone.ext.js
@@ -58,9 +58,6 @@ define(['underscore', 'backbone', 'pubsub'], function (_, Backbone, PubSub) {
 
     });
 
-    // Cached regex to split keys for `delegate`.
-    var delegateEventSplitter = /^(\S+)\s*(.*)$/;
-
     // Helper function to get a value from a Backbone object as a property
     // or as a function.
     var getValue = function (object, prop) {

--- a/js/resthub/jquery-event-destroyed.js
+++ b/js/resthub/jquery-event-destroyed.js
@@ -1,0 +1,37 @@
+define(['jquery'], function ($) {
+
+    /**
+   	 * @attribute destroyed
+   	 * @parent specialevents
+   	 * @download  http://jmvcsite.heroku.com/pluginify?plugins[]=jquery/dom/destroyed/destroyed.js
+   	 * @test jquery/event/destroyed/qunit.html
+   	 * Provides a destroyed event on an element.
+   	 * <p>
+   	 * The destroyed event is called when the element
+   	 * is removed as a result of jQuery DOM manipulators like remove, html,
+   	 * replaceWith, etc. Destroyed events do not bubble, so make sure you don't use live or delegate with destroyed
+   	 * events.
+   	 * </p>
+   	 * <h2>Quick Example</h2>
+   	 * @codestart
+   	 * $(".foo").bind("destroyed", function(){
+   	 *    //clean up code
+   	 * })
+   	 * @codeend
+   	 * <h2>Quick Demo</h2>
+   	 * @demo jquery/event/destroyed/destroyed.html
+   	 * <h2>More Involved Demo</h2>
+   	 * @demo jquery/event/destroyed/destroyed_menu.html
+   	 */
+
+   	var oldClean = jQuery.cleanData;
+
+   	$.cleanData = function( elems ) {
+   		for ( var i = 0, elem;
+   		(elem = elems[i]) !== undefined; i++ ) {
+   			$(elem).triggerHandler("destroyed");
+   			//$.event.remove( elem, 'destroyed' );
+   		}
+   		oldClean(elems);
+   	};
+});

--- a/tests/backbone-refresh-model.js
+++ b/tests/backbone-refresh-model.js
@@ -1,0 +1,118 @@
+require(["jquery", "resthub-backbone"], function ($, Backbone) {
+
+    module("backbone-refresh-model", {
+        setup:function () {
+
+            var Person = Backbone.Model.extend({initialize:function () {
+            }});
+
+            this.TestView = Backbone.View.extend({
+                initialize:function () {
+                    this.render();
+                },
+
+                render:function () {
+                    this.$el.html("<form id='myForm'><input type='text' name='name' value='myName'/><input type='email' name='email' value='email@email.fr'/></form>");
+                    $("#qunit-fixture #main").html(this.el);
+                }
+            });
+
+            this.TestView2 = Backbone.View.extend({
+                initialize:function () {
+                    this.model = new Person();
+                    this.model2 = new Person();
+                    this.render();
+                },
+
+                render:function () {
+                    this.$el.html("<form id='myForm'><input type='text' name='name' value='myName'/><input type='email' name='email' value='email@email.fr'/></form>");
+                    $("#qunit-fixture #main").html(this.el);
+                }
+            });
+        },
+        teardown:function () {
+        }
+    });
+
+    test("View should be rendered", 1, function () {
+        new this.TestView();
+
+        ok($("#qunit-fixture > #main > div").find("myForm"), "HTML content should be rendered");
+    });
+
+    test("no error if no model", 1, function () {
+        var testView = new this.TestView();
+        testView.refreshModel();
+
+        ok(true, "no error");
+    });
+
+    test("model should be set with default values", 3, function () {
+        var testView = new this.TestView2();
+        testView.refreshModel();
+
+        ok(testView.model, "model defined");
+        equal(testView.model.get('name'), "myName", "model name set");
+        equal(testView.model.get('email'), "email@email.fr", "model email set");
+    });
+
+    test("model should be set with explicit jquery form element", 3, function () {
+        var testView = new this.TestView2();
+        testView.refreshModel($("#myForm"));
+
+        ok(testView.model, "model defined");
+        equal(testView.model.get('name'), "myName", "model name set");
+        equal(testView.model.get('email'), "email@email.fr", "model email set");
+    });
+
+    test("model should be set with explicit jquery selector", 3, function () {
+        var testView = new this.TestView2();
+        testView.refreshModel("#myForm");
+
+        ok(testView.model, "model defined");
+        equal(testView.model.get('name'), "myName", "model name set");
+        equal(testView.model.get('email'), "email@email.fr", "model email set");
+    });
+
+    test("no error with insistent form", 6, function () {
+        var testView = new this.TestView2();
+        testView.refreshModel("#noForm");
+
+        ok(testView.model, "model defined");
+        equal(testView.model.get('name'), undefined, "model name undefined");
+        equal(testView.model.get('email'), undefined, "model email undefined");
+
+        testView.refreshModel($("#noForm"));
+
+        ok(testView.model, "model defined");
+        equal(testView.model.get('name'), undefined, "model name undefined");
+        equal(testView.model.get('email'), undefined, "model email undefined");
+    });
+
+    test("model should be set with explicit model", 6, function () {
+        var testView = new this.TestView2();
+        testView.refreshModel(null, testView.model2);
+
+        ok(testView.model, "model defined");
+        equal(testView.model.get('name'), undefined, "model name undefined");
+        equal(testView.model.get('email'), undefined, "model email undefined");
+
+        ok(testView.model2, "model2 defined");
+        equal(testView.model2.get('name'), "myName", "model name set");
+        equal(testView.model2.get('email'), "email@email.fr", "model email set");
+    });
+
+    test("model should be set with explicit model and form", 6, function () {
+        var testView = new this.TestView2();
+        testView.refreshModel($("#myForm"), testView.model2);
+
+        ok(testView.model, "model defined");
+        equal(testView.model.get('name'), undefined, "model name undefined");
+        equal(testView.model.get('email'), undefined, "model email undefined");
+
+        ok(testView.model2, "model2 defined");
+        equal(testView.model2.get('name'), "myName", "model name set");
+        equal(testView.model2.get('email'), "email@email.fr", "model email set");
+    });
+
+});

--- a/tests/backbone-remove.js
+++ b/tests/backbone-remove.js
@@ -54,12 +54,12 @@ require(["jquery", "resthub-backbone"], function ($, Backbone) {
         equal(testView.counts.dispose, 1, "dispose called only once");
 
         testView.$el.remove();
-        equal(testView.counts.dispose, 1, "dispose not called anymore");
+        equal(testView.counts.dispose, 2, "dispose called once again");
 
         testView = new this.TestView2();
 
         testView.$el.remove();
-        equal(testView.counts.dispose, 1, "dispose called once");
+        equal(testView.counts.dispose, 1, "dispose called once again");
     });
 
     test("remove on parent should call dispose", 1, function () {

--- a/tests/backbone-remove.js
+++ b/tests/backbone-remove.js
@@ -1,0 +1,110 @@
+require(["jquery", "resthub-backbone"], function ($, Backbone) {
+
+    module("backbone-remove", {
+        setup:function () {
+            this.TestView = Backbone.View.extend({
+                initialize:function () {
+                    this.text = 'HTML Content';
+                    this.render();
+                },
+
+                render:function () {
+                    this.$el.html(this.text);
+                    $("#qunit-fixture #main").html(this.el);
+                }
+            });
+            this.TestView2 = Backbone.View.extend({
+                initialize:function () {
+                    this.counts = {};
+                    this.text = 'HTML Content 2';
+                    this.render();
+                },
+
+                render:function () {
+                    this.$el.html(this.text);
+                    $("#qunit-fixture #main").html(this.el);
+                },
+
+                dispose:function () {
+                    this.counts.dispose = (this.counts.dispose || 0) + 1;
+                }
+            });
+        },
+        teardown:function () {
+        }
+    });
+
+    test("View should be rendered", 1, function () {
+        var testView = new this.TestView();
+
+        equal($("#qunit-fixture > #main > div").html(), testView.text, "HTML content should be rendered");
+    });
+
+    test("remove should delete html", 1, function () {
+        var testView = new this.TestView();
+        testView.remove();
+
+        equal($("#qunit-fixture #main").html(), "", "no HTML content should be rendered");
+    });
+
+    test("remove should call dispose", 3, function () {
+        var testView = new this.TestView2();
+
+        testView.remove();
+        equal(testView.counts.dispose, 1, "dispose called only once");
+
+        testView.$el.remove();
+        equal(testView.counts.dispose, 1, "dispose not called anymore");
+
+        testView = new this.TestView2();
+
+        testView.$el.remove();
+        equal(testView.counts.dispose, 1, "dispose called once");
+    });
+
+    test("remove on parent should call dispose", 1, function () {
+        var testView = new this.TestView2();
+
+        testView.$el.parent().remove();
+        equal(testView.counts.dispose, 1, "dispose called");
+    });
+
+    test("html should not call dispose", 1, function () {
+        var testView = new this.TestView2();
+
+        testView.$el.html("test");
+        equal(testView.counts.dispose, undefined, "dispose not called");
+    });
+
+    test("html on parents should call dispose", 2, function () {
+        var testView = new this.TestView2();
+
+        testView.$el.parent().html("test");
+        equal(testView.counts.dispose, 1, "dispose called");
+
+        testView = new this.TestView2();
+
+        testView.$el.parent().parent().html("test");
+        equal(testView.counts.dispose, 1, "dispose called");
+    });
+
+    test("empty should not call dispose", 1, function () {
+        var testView = new this.TestView2();
+
+        testView.$el.empty();
+        equal(testView.counts.dispose, undefined, "dispose not called");
+    });
+
+    test("empty on parents should call dispose", 2, function () {
+        var testView = new this.TestView2();
+
+        testView.$el.parent().empty();
+        equal(testView.counts.dispose, 1, "dispose called");
+
+        testView = new this.TestView2();
+
+        testView.$el.parent().parent().empty();
+        equal(testView.counts.dispose, 1, "dispose called");
+    });
+
+});

--- a/tests/qunit/run-qunit.js
+++ b/tests/qunit/run-qunit.js
@@ -13,7 +13,7 @@ var system = require('system');
  * @param timeOutMillis the max amount of time to wait. If not specified, 3 sec is used.
  */
 function waitFor(testFx, onReady, timeOutMillis) {
-    var maxtimeOutMillis = timeOutMillis ? timeOutMillis : 3001, //< Default Max Timout is 3s
+    var maxtimeOutMillis = timeOutMillis ? timeOutMillis : 10001, //< Default Max Timout is 3s
         start = new Date().getTime(),
         condition = false,
         interval = setInterval(function() {

--- a/tests/qunit/run-qunit.js
+++ b/tests/qunit/run-qunit.js
@@ -13,7 +13,7 @@ var system = require('system');
  * @param timeOutMillis the max amount of time to wait. If not specified, 3 sec is used.
  */
 function waitFor(testFx, onReady, timeOutMillis) {
-    var maxtimeOutMillis = timeOutMillis ? timeOutMillis : 10001, //< Default Max Timout is 3s
+    var maxtimeOutMillis = timeOutMillis ? timeOutMillis : 10001, //< Default Max Timout is 10s
         start = new Date().getTime(),
         condition = false,
         interval = setInterval(function() {

--- a/tests/suite.js
+++ b/tests/suite.js
@@ -56,8 +56,9 @@ require.config({
         'backbone-paginator':'libs/backbone.paginator',
         'backbone-queryparams':'libs/backbone.queryparams',
         keymaster:'libs/keymaster',
-        hbs: 'resthub/handlebars-require'
+        hbs:'resthub/handlebars-require'
     }
 });
 
-require(['../tests/pubsub', '../tests/handlebars-helpers', '../tests/inclusions', '../tests/handlebars-require', '../tests/resthub-backbone-pubsub']);
+require(['../tests/pubsub', '../tests/handlebars-helpers', '../tests/inclusions',
+    '../tests/handlebars-require', '../tests/resthub-backbone-pubsub', '../tests/backbone-remove']);

--- a/tests/suite.js
+++ b/tests/suite.js
@@ -61,4 +61,5 @@ require.config({
 });
 
 require(['../tests/pubsub', '../tests/handlebars-helpers', '../tests/inclusions',
-    '../tests/handlebars-require', '../tests/resthub-backbone-pubsub', '../tests/backbone-remove']);
+    '../tests/handlebars-require', '../tests/resthub-backbone-pubsub', '../tests/backbone-remove',
+    '../tests/backbone-refresh-model']);


### PR DESCRIPTION
This PR contains :
- binding of `Backbone.dispose` on $el.remove. fixes #11
- extend `Backbone.dispose` to unbind `Backbone.Validation` . fixes #11
- add basic helper to copy form fields to model. fixes #30
