### PR TITLE
fix pubsub undelegate problem and add onDispose mehod

### DIFF
--- a/js/main.js
+++ b/js/main.js
@@ -60,7 +60,7 @@ require.config({
         'resthub-handlebars':'resthub/handlebars-helpers',
         'backbone-queryparams':'libs/backbone.queryparams',
         'backbone-paginator':'libs/backbone.paginator',
-        async:'libs/async.js',
+        async:'libs/async',
         keymaster:'libs/keymaster',
         hbs:'resthub/handlebars-require'
     }

--- a/js/resthub/backbone.ext.js
+++ b/js/resthub/backbone.ext.js
@@ -5,7 +5,6 @@ define(['underscore', 'backbone-orig', 'pubsub', 'resthub/jquery-event-destroyed
 
     var originalPrototype = Backbone.View.prototype;
     var originalDelegateEvents = originalPrototype.delegateEvents;
-    var originalUndelegateEvents = originalPrototype.undelegateEvents;
     var originalSetElement = originalPrototype.setElement;
     var originalRemove = originalPrototype.remove;
     var originalDispose = originalPrototype.dispose;
@@ -53,11 +52,6 @@ define(['underscore', 'backbone-orig', 'pubsub', 'resthub/jquery-event-destroyed
             }, this));
         },
 
-        undelegateEvents:function () {
-            PubSub.off(null, null, this);
-            originalUndelegateEvents.call(this);
-        },
-
         // Override backbone setElement to bind a destroyed special event
         // when el is detached from DOM
         setElement:function (element, delegate) {
@@ -88,6 +82,7 @@ define(['underscore', 'backbone-orig', 'pubsub', 'resthub/jquery-event-destroyed
         // Bindings if defined
         dispose:function () {
             originalDispose.call(this);
+            PubSub.off(null, null, this);
 
             if (Backbone.Validation) {
                 Backbone.Validation.unbind(this)

--- a/js/resthub/backbone.ext.js
+++ b/js/resthub/backbone.ext.js
@@ -81,6 +81,10 @@ define(['underscore', 'backbone-orig', 'pubsub', 'resthub/jquery-event-destroyed
         // Override Backbone dispose method to unbind Backbone Validation
         // Bindings if defined
         dispose:function () {
+
+            // perform actions before effective close
+            this.onDispose();
+
             originalDispose.call(this);
             PubSub.off(null, null, this);
 
@@ -88,6 +92,10 @@ define(['underscore', 'backbone-orig', 'pubsub', 'resthub/jquery-event-destroyed
                 Backbone.Validation.unbind(this)
             }
 
+            return this;
+        },
+
+        onDispose:function () {
             return this;
         },
 

--- a/tests/qunit/run-qunit.js
+++ b/tests/qunit/run-qunit.js
@@ -13,7 +13,7 @@ var system = require('system');
  * @param timeOutMillis the max amount of time to wait. If not specified, 3 sec is used.
  */
 function waitFor(testFx, onReady, timeOutMillis) {
-    var maxtimeOutMillis = timeOutMillis ? timeOutMillis : 10001, //< Default Max Timout is 10s
+    var maxtimeOutMillis = timeOutMillis ? timeOutMillis : 30001, //< Default Max Timout is 10s
         start = new Date().getTime(),
         condition = false,
         interval = setInterval(function() {

--- a/tests/resthub-backbone-pubsub.js
+++ b/tests/resthub-backbone-pubsub.js
@@ -63,10 +63,20 @@ require(["backbone", "pubsub"], function (Backbone, pubsub) {
 
                 initialize:function () {
                     this.counts = {};
+                    Pubsub.on("!global2", this.global2Fired, this);
+                    Pubsub.on("!global3", this.global3Fired, this);
                 },
 
                 globalFired:function () {
                     this.counts.globalFired = (this.counts.globalFired || 0) + 1;
+                },
+
+                global2Fired:function () {
+                    this.counts.global2Fired = (this.counts.global2Fired || 0) + 1;
+                },
+
+                global3Fired:function () {
+                    this.counts.global3Fired = (this.counts.global3Fired || 0) + 1;
                 }
             });
         },
@@ -190,6 +200,34 @@ require(["backbone", "pubsub"], function (Backbone, pubsub) {
 
         equal(testView.counts.globalFired, 1, "globalFired not called on testView");
         equal(testView2.counts.globalFired, 2, "globalFired called on testView2");
+
+    });
+
+    test("should publish pubsub events declared on initialize", 6, function () {
+
+        var testView = new this.TestView3();
+
+        pubsub.trigger("!global2");
+        pubsub.trigger("!global3");
+
+        equal(testView.counts.global2Fired, 1, "global2Fired called on testView");
+        equal(testView.counts.global3Fired, 1, "global3Fired called on testView");
+
+        testView.undelegateEvents();
+
+        pubsub.trigger("!global2");
+        pubsub.trigger("!global3");
+
+        equal(testView.counts.global2Fired, 2, "global2Fired called on testView");
+        equal(testView.counts.global3Fired, 2, "global3Fired called on testView");
+
+        testView.dispose();
+
+        pubsub.trigger("!global2");
+        pubsub.trigger("!global3");
+
+        equal(testView.counts.global2Fired, 2, "global2Fired not called on testView");
+        equal(testView.counts.global3Fired, 2, "global3Fired not called on testView");
 
     });
 


### PR DESCRIPTION
Current `unDelegate` override remove Pubsub binding and that works fine for bindings declared on `events` hash (and so bound immediately after initialize call).

But this does not work with PubSub event registered manually in initialize because `delegateEvents` is called after initialized and start by calling `unDelegateEvents`, removing all PubSub bindings !

New implementation unregister pubsub events on dispose method only.

Also add a hook on dispose to start by calling a default empty `onDispose` method that can be called by users to perform actions before effective `dispose`
