### PR TITLE
populateModel globally

### DIFF
--- a/js/resthub/backbone.ext.js
+++ b/js/resthub/backbone.ext.js
@@ -172,14 +172,11 @@ define(['underscore', 'backbone-orig', 'pubsub', 'resthub/jquery-event-destroyed
             return this;
         },
 
-        /** utility method providing a default and basic handler that
-         * populate model from a form input
-         *
-         * @param form form element to 'parse'. form parameter could be a css selector or a
-         * jQuery element. if undefined, the first form of this view el is used.
-         * @param model model instance to populate. if no model instance is provided,
-         * search for 'this.model'
-         **/
+        // populate model from a form input
+        //
+        // form parameter could be a css selector or a jQuery element. if undefined,
+        // the first form of this view el is used.
+        // if no model instance is provided, search for 'this.model'
         populateModel: function(form, model) {
             var attributes = {};
 
@@ -192,10 +189,11 @@ define(['underscore', 'backbone-orig', 'pubsub', 'resthub/jquery-event-destroyed
             // build array of form attributes to refresh model
             fields.each(_.bind(function(index, value) {
                 attributes[value.name] = value.value;
-                if (model) {
-                    model.set(value.name, value.value);
-                }
             }, this));
+
+            if (model) {
+                model.set(attributes);
+            }
         }
 
     });


### PR DESCRIPTION
old populateModel implementation performed one by one model assignation by calling set method for each form field.

new one set all attributes globally to fix a problem on validation that could lead to validate an invalid model.

An example will help to understand :

Let's imagine that we have a form with two fields firstname & lastname and a model with Backbone Validation with both firstname and lastname attributes required.
1. If, on form validation (with empty form), we call model.set one by one, two validation errors will be displayed.
2. If we change firstname to `test` and submit again, we will get only validation error for lastname
3. If we set firstname to "" again and validate the form, we will get only validation error for lastname !!!

This is because, on set, backbone call validate with a hash of attributes that is a merge of modified attributes with existing model attributes.

So when calling `set('firstname', '')` backbone display an error on firstname, as expected. But immediately after, we call `set('lastname', '')` backbone will merge firstanme new value with firstname old value stored in model. And, because, the invalid value '' was never stored, the valid 'test' value is taken !!!

To fix that point, `populateModel` set all model attributes in one operation building an attribute hash and calling `set(attributes)`.

To validate fields one by one, just call `validate()` that triggers correctly but does not produce this side effect.
