### PR TITLE
 Call context.toJSON() if context.toJSON is defined even if the context is passed directly

### DIFF
--- a/js/libs/resthub/backbone.ext.js
+++ b/js/libs/resthub/backbone.ext.js
@@ -63,9 +63,9 @@ define(['underscore', 'backbone-orig', 'pubsub', 'libs/resthub/jquery-event-dest
                     }, this);
                     context = this[key];
                 }
-                if (context && context.toJSON) {
-                    context = context.toJSON();
-                }
+            }
+            if (context && context.toJSON) {
+                context = context.toJSON();
             }
             // Maybe throw an error if the context could not be determined
             // instead of returning {}


### PR DESCRIPTION
Related to #51.
