### PR TITLE
Fix hbs module in order to pass r.js optimization. 

### DIFF
--- a/js/libs/resthub/require-handlebars.js
+++ b/js/libs/resthub/require-handlebars.js
@@ -14,9 +14,13 @@ define(['module'], function(module) {
             var textName = 'text!' + name + '.' + extension;
 
             return req(['handlebars', textName], function (Handlebars, template) {
-                load((Handlebars ? Handlebars.compile(template) : template));
-            }
-            );
+                if(!config.isBuild) {
+                    load(Handlebars.compile(template));
+                }
+                else {
+                    load(template);
+                }
+            });
         }
     };
 

--- a/js/libs/resthub/require-handlebars.js
+++ b/js/libs/resthub/require-handlebars.js
@@ -1,23 +1,24 @@
 define(['module'], function(module) {
 
-  var masterConfig = module.config();
+    var masterConfig = (module.config && module.config()) || {};
 
-  var hbs = {
-    load: function (name, req, load, config) {
-      config = config || {};
-      var extension = masterConfig.extension;
-      if (config.extension) {
-        extension = config.extension;
-      }
-      extension = extension || 'hbs';
-      var textName = 'text!' + name + '.' + extension;
+    var hbs = {
+        load: function (name, req, load, config) {
+            config = config || {};
+            
+            var extension = masterConfig.extension;
+            if (config.extension) {
+                extension = config.extension;
+            }
+            extension = extension || 'hbs';
+            var textName = 'text!' + name + '.' + extension;
 
-      return req(['handlebars', textName], function (Handlebars, template) {
-          load(Handlebars.compile(template));
+            return req(['handlebars', textName], function (Handlebars, template) {
+                load((Handlebars ? Handlebars.compile(template) : template));
+            }
+            );
         }
-      );
-    }
-  };
+    };
 
-  return hbs;
+    return hbs;
 });


### PR DESCRIPTION
When r.js optimization is runned, Handlerbars module is null when called whit req().
I didn't found why but I added a test to avoid that issue during the compilation.
