### PR TITLE
'labels' property in ResthubView is automatically added to the render context.

### DIFF
--- a/js/lib/resthub/backbone-resthub.js
+++ b/js/lib/resthub/backbone-resthub.js
@@ -34,6 +34,9 @@ define(['underscore', 'backbone-orig', 'pubsub', 'lib/resthub/jquery-event-destr
                 throw new Error('Invalid template provided.');
             }
             context = this._ensureContext(context);
+            if (this.labels) {
+                context.labels = this.labels;
+            }
             this.$el.html(this.template(context));
             return this;
         },

--- a/tests/backbone-i18n.js
+++ b/tests/backbone-i18n.js
@@ -1,0 +1,60 @@
+require(["jquery",
+         "backbone",
+         "i18n!../tests/nls/labels",
+         "i18n!../tests/nls/zz-qq/labels",
+         "hbs!../tests/templates/template2"],
+function($, Backbone, labels, labels_zzqq, template2) {
+
+    module("backbone-i18n", {
+        setup: function() {
+            this.TestView = Backbone.ResthubView.extend({
+                labels: labels,
+                template: template2,
+                root: "#qunit-fixture #main",
+                
+                initialize: function() {
+                    this.render();
+                }
+            });
+            
+            this.TestView2 = Backbone.ResthubView.extend({
+                template: template2,
+                root: "#qunit-fixture #main",
+                
+                initialize: function() {
+                    this.render();
+                }
+            });
+            
+            this.TestView3 = Backbone.ResthubView.extend({
+                labels: labels_zzqq,
+                template: template2,
+                root: "#qunit-fixture #main",
+                
+                initialize: function() {
+                    this.render();
+                }
+            });
+        },
+        teardown: function() {
+        }
+    });
+
+    test("'labels.val' should be remplaced by 'value'", 1, function() {
+        new this.TestView();
+
+        equal($("#qunit-fixture > #main > div").html(), "This is a value from labels.");
+    });
+
+    test("'labels.val' should not be rendered", 1, function() {
+        new this.TestView2();
+
+        equal($("#qunit-fixture > #main > div").html(), "This is a  from labels.");
+    });
+
+    test("'labels.val' should be remplaced by 'valeur'", 1, function() {
+        new this.TestView3();
+
+        equal($("#qunit-fixture > #main > div").html(), "This is a valeur from labels.");
+    });
+});

--- a/tests/nls/labels.js
+++ b/tests/nls/labels.js
@@ -1,0 +1,6 @@
+define({
+    "root": {
+        "val": "value"
+    },
+    "zz-qq": true
+});

--- a/tests/nls/zz-qq/labels.js
+++ b/tests/nls/zz-qq/labels.js
@@ -1,0 +1,3 @@
+define({
+    "val": "valeur"
+});

--- a/tests/suite.js
+++ b/tests/suite.js
@@ -87,4 +87,4 @@ require.config({
 
 require(['../tests/pubsub', '../tests/handlebars-helpers', '../tests/inclusions',
     '../tests/require-handlebars', '../tests/backbone-pubsub', '../tests/backbone-remove',
-    '../tests/backbone-populate-model', '../tests/backbone-history']);
+    '../tests/backbone-populate-model', '../tests/backbone-history', '../tests/backbone-i18n']);

--- a/tests/templates/template2.hbs
+++ b/tests/templates/template2.hbs
@@ -1,0 +1,1 @@
+This is a {{labels.val}} from labels.


### PR DESCRIPTION
`labels` becomes a keyword like `template`, `strategy`, `tagName` or `className`.
