### PR TITLE
Split old main.js to new main.js (require.js initialization provided by the framework) + app.js (user application)

### DIFF
--- a/js/app.js
+++ b/js/app.js
@@ -1,0 +1,3 @@
+define(['router/app-router'], function(AppRouter) {
+    new AppRouter();
+});

--- a/js/main.js
+++ b/js/main.js
@@ -81,8 +81,5 @@ require.config({
     }
 });
 
-require(['router/app-router'], function(AppRouter) {
-
-    new AppRouter();
-
-});
+// Load our app module and pass it to our definition function
+require(['app']);


### PR DESCRIPTION
The main reason is make easier Backbone stack update (we just have to override main.js, all custom app code is in app.js)
