### PR TITLE
Add support for client logging

### DIFF
--- a/js/lib/resthub/console.js
+++ b/js/lib/resthub/console.js
@@ -1,10 +1,111 @@
-/* console.log() shim from html5 boilerplate */
-define(function() {
-    // usage: log('inside coolFunc', this, arguments);
-    // paulirish.com/2009/log-a-lightweight-wrapper-for-consolelog/
-    window.log = function f(){ log.history = log.history || []; log.history.push(arguments); if(this.console) { var args = arguments, newarr; try { args.callee = f.caller } catch(e) {}; newarr = [].slice.call(args); if (typeof console.log === 'object') log.apply.call(console.log, console, newarr); else console.log.apply(console, newarr);}};
+define(['jquery'], function ($) {
 
-    // make it safe to use console.log always
-    (function(a){function b(){}for(var c="assert,count,debug,dir,dirxml,error,exception,group,groupCollapsed,groupEnd,info,log,markTimeline,profile,profileEnd,time,timeEnd,trace,warn".split(","),d;!!(d=c.pop());){a[d]=a[d]||b;}})
-    (function(){try{console.log();return window.console;}catch(a){return (window.console={});}}());
+// In case we forget to take out console statements. IE becomes very unhappy when we forget. Let's not make IE unhappy
+    if(typeof(window.console) === 'undefined') {
+        window.console = {};
+        console.log = console.error = console.info = console.debug = console.warn = console.trace = console.dir = console.dirxml = console.group = console.groupEnd = console.time = console.timeEnd = console.assert = console.profile = function() {};
+    }
+
+    var console = window.console;
+
+    // manage IE8 & 9
+    var methods = ["log","info","warn","error","assert","dir","clear","profile","profileEnd"];
+    if (Function.prototype.bind && console && typeof console.log == "object") {
+        methods.forEach(function (method) {
+            console[method] = this.call(console[method], console);
+        }, Function.prototype.bind);
+    }
+
+    console.buffer = [];
+    console.BUFFER_MAX_SIZE = 10;
+    // override if needed
+    console.serverUrl = "api/logs";
+
+    // Helper to define a logging level object; helps with optimisation.
+    var defineLogLevel = function(value, name) {
+        return { value: value, name: name };
+    };
+
+    var Levels= {};
+    Levels.DEBUG = defineLogLevel(1, 'DEBUG');
+    Levels.INFO = defineLogLevel(2, 'INFO');
+    Levels.WARN = defineLogLevel(4, 'WARN');
+    Levels.ERROR = defineLogLevel(8, 'ERROR');
+    Levels.OFF = defineLogLevel(99, 'OFF');
+    console.Levels = Levels;
+
+    //default level
+    console.level = Levels.DEBUG;
+
+    var enabledFor = function (lvl) {
+        var filterLevel = console.level;
+        return lvl.value >= filterLevel.value;
+    };
+
+    var log = console.log;
+    var debug = console.debug;
+    var info = console.info;
+    var warn = console.warn;
+    var error = console.error;
+    console.log = function () {
+        log.apply(this, Array.prototype.slice.call(arguments));
+        //sendToServer("error", arguments);
+    };
+    console.debug = function () {
+        debug.apply(this, Array.prototype.slice.call(arguments));
+        if(enabledFor(Levels.DEBUG)){
+            bufferLog("DEBUG", arguments);
+        }
+    };
+    console.info = function () {
+        info.apply(this, Array.prototype.slice.call(arguments));
+        if(enabledFor(Levels.INFO)){
+            bufferLog("INFO", arguments);
+        }
+    };
+    console.warn = function () {
+        warn.apply(this, Array.prototype.slice.call(arguments));
+        if(enabledFor(Levels.WARN)){
+            bufferLog("WARN", arguments);
+        }
+    };
+    console.error = function () {
+        error.apply(this, Array.prototype.slice.call(arguments));
+        if(enabledFor(Levels.ERROR)){
+            bufferLog("ERROR", arguments);
+        }
+    };
+
+    var bufferLog = function(level, msg){
+        var message = typeof msg === "object" ? JSON.stringify(msg) : msg;
+        var log = {"level":level, "message": message, "time": new Date()};
+        console.buffer.push(log);
+        if(console.buffer.length == console.BUFFER_MAX_SIZE){
+            // could some logs be lost ?
+            sendLogsToServer();
+        }
+    };
+
+    var sendLogsToServer = function(){
+        $.ajax({
+            type: 'POST',
+            url: console.serverUrl,
+            data: JSON.stringify(console.buffer),
+            contentType:"application/json",
+            success: function(){
+                // update log level
+            }
+        });
+        console.buffer = [];
+    }
+
+    // on page change/reload send the content of the buffer
+    window.onunload = function(){
+        sendLogsToServer();
+    }
+
+    // manage global JS errors
+    window.onerror = function(message, url, linenumber){
+        bufferLog("ERROR", "JavaScript error: " + message + " on line " + linenumber + " for " + url);
+    }
 });

--- a/pom.xml
+++ b/pom.xml
@@ -82,6 +82,11 @@
             <name>Brian Clozel</name>
             <timezone>+1</timezone>
         </developer>
+        <developer>
+            <id>jripault</id>
+            <name>Julien Ripault</name>
+            <timezone>+1</timezone>
+        </developer>
     </developers>
     <scm>
         <connection>scm:git:https://github.com/resthub/resthub-backbone-stack.git</connection>

--- a/tests/console.js
+++ b/tests/console.js
@@ -1,0 +1,40 @@
+require(['console'], function () {
+
+    module('console', {
+        setup: function() {
+            console.buffer = [];
+        },
+        teardown: function() {
+        }
+    });
+
+    test("'buffer must fill up", function() {
+        console.info("An info");
+        console.debug("A debug");
+        console.warn("A warn");
+        console.error("An error");
+
+        equal(console.buffer.length, 4);
+    });
+
+    test("'buffer must be empty after sending to server", function() {
+        console.BUFFER_MAX_SIZE = 3;
+
+        console.info("An info");
+        console.debug("A debug");
+        console.warn("A warn");
+        equal(console.buffer.length, 0);
+    });
+
+    test("'buffer must contains only logs equal or superior to the set level", function() {
+        console.level = console.Levels.WARN;
+
+        console.info("An info");
+        console.debug("A debug");
+        console.warn("A warn");
+        console.error("An error");
+        equal(console.buffer.length, 2);
+    });
+
+
+});

--- a/tests/suite.js
+++ b/tests/suite.js
@@ -81,10 +81,11 @@ require.config({
         keymaster: 'lib/keymaster',
         hbs: 'lib/resthub/require-handlebars',
         'moment': 'lib/moment',
-        'moment-fr': 'lib/moment-lang/fr'
+        'moment-fr': 'lib/moment-lang/fr',
+        console: 'lib/resthub/console'
     }
 });
 
 require(['../tests/pubsub', '../tests/handlebars-helpers', '../tests/inclusions',
     '../tests/require-handlebars', '../tests/backbone-pubsub', '../tests/backbone-remove',
-    '../tests/backbone-populate-model', '../tests/backbone-history', '../tests/backbone-i18n']);
+    '../tests/backbone-populate-model', '../tests/backbone-history', '../tests/console', '../tests/backbone-i18n']);


### PR DESCRIPTION
Add a shim for the console to enable sending logs to the server. The console now have a buffer that is sent when the buffer limit is reached (limit to define). The level can be defined between debug, info, warn, error, off.
