### PR TITLE
Client logging improvements

### DIFF
--- a/js/lib/moment-lang/fr.js
+++ b/js/lib/moment-lang/fr.js
@@ -1,4 +1,4 @@
-﻿// moment.js language configuration
+// moment.js language configuration
 // language : french (fr)
 // author : John Fischer : https://github.com/jfroffice
 (function () {

--- a/js/lib/resthub/backbone-resthub.js
+++ b/js/lib/resthub/backbone-resthub.js
@@ -39,7 +39,7 @@ define(['underscore', 'backbone-orig', 'pubsub', 'lib/resthub/jquery-event-destr
         },
 
         _ensureContext: function(context) {
-            if (typeof context === "undefined") {
+            if ((typeof context === "undefined") || (typeof context !== 'object')) {
                 // Dynamic context provided as a function
                 if(_.isFunction(this.context)) {
                     context = this.context();

--- a/js/lib/resthub/console.js
+++ b/js/lib/resthub/console.js
@@ -9,37 +9,28 @@ define(['jquery'], function ($) {
     var console = window.console;
 
     // manage IE8 & 9
-    var methods = ["log","info","warn","error","assert","dir","clear","profile","profileEnd"];
-    if (Function.prototype.bind && console && typeof console.log == "object") {
+    var methods = ['log','info','warn','error','assert','dir','clear','profile','profileEnd'];
+    if (Function.prototype.bind && console && typeof console.log === 'object') {
         methods.forEach(function (method) {
             console[method] = this.call(console[method], console);
         }, Function.prototype.bind);
     }
 
-    console.buffer = [];
-    console.BUFFER_MAX_SIZE = 10;
-    // override if needed
-    console.serverUrl = "api/logs";
-
-    // Helper to define a logging level object; helps with optimisation.
-    var defineLogLevel = function(value, name) {
-        return { value: value, name: name };
-    };
-
-    var Levels= {};
-    Levels.DEBUG = defineLogLevel(1, 'DEBUG');
-    Levels.INFO = defineLogLevel(2, 'INFO');
-    Levels.WARN = defineLogLevel(4, 'WARN');
-    Levels.ERROR = defineLogLevel(8, 'ERROR');
-    Levels.OFF = defineLogLevel(99, 'OFF');
-    console.Levels = Levels;
-
-    //default level
-    console.level = Levels.DEBUG;
-
-    var enabledFor = function (lvl) {
-        var filterLevel = console.level;
-        return lvl.value >= filterLevel.value;
+    // Can be customized if needed
+    console.serverUrl = 'api/log';
+    console.levels = ['debug', 'info', 'warn', 'error'];
+    // Disabled by default
+    console.level = 'off';
+    
+    var enabledFor = function (level) {
+        if(console.level === 'off') return false;
+        if (_.indexOf(console.levels, level) === -1) {
+            throw new Error('Invalid log level "' + strategy + '", must be one of ' + JSON.stringify(console.levels));
+        }
+        if (_.indexOf(console.levels, console.level) === -1) {
+            throw new Error('Invalid log console.level "' + strategy + '", must be one of ' + JSON.stringify(console.levels));
+        }
+        return _.indexOf(console.levels, level) >= _.indexOf(console.levels, console.level);
     };
 
     var log = console.log;
@@ -47,65 +38,62 @@ define(['jquery'], function ($) {
     var info = console.info;
     var warn = console.warn;
     var error = console.error;
+    
+    // console.log = console.debug
     console.log = function () {
         log.apply(this, Array.prototype.slice.call(arguments));
-        //sendToServer("error", arguments);
+        if(enabledFor('debug')){
+            sendLogToServer('debug', arguments);
+        }
     };
     console.debug = function () {
         debug.apply(this, Array.prototype.slice.call(arguments));
-        if(enabledFor(Levels.DEBUG)){
-            bufferLog("DEBUG", arguments);
+        if(enabledFor('debug')){
+            sendLogToServer('debug', arguments);
         }
     };
     console.info = function () {
         info.apply(this, Array.prototype.slice.call(arguments));
-        if(enabledFor(Levels.INFO)){
-            bufferLog("INFO", arguments);
+        if(enabledFor('info')){
+            sendLogToServer('info', arguments);
         }
     };
     console.warn = function () {
         warn.apply(this, Array.prototype.slice.call(arguments));
-        if(enabledFor(Levels.WARN)){
-            bufferLog("WARN", arguments);
+        if(enabledFor('warn')){
+            sendLogToServer('warn', arguments);
         }
     };
     console.error = function () {
         error.apply(this, Array.prototype.slice.call(arguments));
-        if(enabledFor(Levels.ERROR)){
-            bufferLog("ERROR", arguments);
+        if(enabledFor('error')){
+            sendLogToServer('error', arguments);
         }
     };
 
-    var bufferLog = function(level, msg){
-        var message = typeof msg === "object" ? JSON.stringify(msg) : msg;
-        var log = {"level":level, "message": message, "time": new Date()};
-        console.buffer.push(log);
-        if(console.buffer.length == console.BUFFER_MAX_SIZE){
-            // could some logs be lost ?
-            sendLogsToServer();
-        }
-    };
 
-    var sendLogsToServer = function(){
+    var sendLogToServer = function(level, msg){
+        if((typeof msg === 'object') && (msg.length === 1) && (typeof msg[0] === 'string')){
+            var message = msg[0];
+        } else {
+            var message = JSON.stringify(msg);
+        }
+
+        var log = {'level':level, 'message': message, 'time': new Date()};
+        
         $.ajax({
             type: 'POST',
             url: console.serverUrl,
-            data: JSON.stringify(console.buffer),
-            contentType:"application/json",
+            data: JSON.stringify(log),
+            contentType:'application/json',
             success: function(){
                 // update log level
             }
         });
-        console.buffer = [];
-    }
-
-    // on page change/reload send the content of the buffer
-    window.onunload = function(){
-        sendLogsToServer();
-    }
+    };
 
     // manage global JS errors
     window.onerror = function(message, url, linenumber){
-        bufferLog("ERROR", "JavaScript error: " + message + " on line " + linenumber + " for " + url);
-    }
+        sendLogToServer('error', 'JavaScript error: ' + message + ' on line ' + linenumber + ' for ' + url);
+    };
 });

--- a/js/main.js
+++ b/js/main.js
@@ -76,10 +76,11 @@ require.config({
         async: 'lib/async',
         keymaster: 'lib/keymaster',
         hbs: 'lib/resthub/require-handlebars',
-        'moment': 'lib/moment',
-        template: '../template'
+        moment: 'lib/moment',
+        template: '../template',
+        console: 'lib/resthub/console'
     }
 });
 
 // Load our app module and pass it to our definition function
-require(['app']);
+require(['console', 'app']);

--- a/tests/console.js
+++ b/tests/console.js
@@ -1,40 +1,15 @@
 require(['console'], function () {
 
-    module('console', {
-        setup: function() {
-            console.buffer = [];
-        },
-        teardown: function() {
-        }
-    });
+    module('console');
 
-    test("'buffer must fill up", function() {
+    // In order to verify that it works under all browser
+    test("Test each console log method", function() {
         console.info("An info");
         console.debug("A debug");
+        console.log("A log");
         console.warn("A warn");
         console.error("An error");
-
-        equal(console.buffer.length, 4);
+        ok(true);
     });
-
-    test("'buffer must be empty after sending to server", function() {
-        console.BUFFER_MAX_SIZE = 3;
-
-        console.info("An info");
-        console.debug("A debug");
-        console.warn("A warn");
-        equal(console.buffer.length, 0);
-    });
-
-    test("'buffer must contains only logs equal or superior to the set level", function() {
-        console.level = console.Levels.WARN;
-
-        console.info("An info");
-        console.debug("A debug");
-        console.warn("A warn");
-        console.error("An error");
-        equal(console.buffer.length, 2);
-    });
-
 
 });


### PR DESCRIPTION
By default, logging is now disabled (better since is is optional also on serverside).
Try to follow Backbone/RESThub style for parameters (doc update to follow)
Remove bufer since tests are NOK (no log sent when closing the browser or goging to another page)
