### PR TITLE
resthub-validation: add the capacity to define custom messages per property and type

### DIFF
--- a/js/lib/resthub/resthub.js
+++ b/js/lib/resthub/resthub.js
@@ -257,10 +257,16 @@ define(['underscore', 'backbone', 'jquery', 'lib/resthub/jquery-event-destroyed'
         var constraintMessage = function(propKey, constraint, messages) {
             var msg = constraint.message;
 
+            var msgPropKey = 'validation.' + propKey + '.' +  constraint.type + '.message';
             var msgKey = 'validation.' + constraint.type + '.message';
 
-            if (messages && messages[msgKey]) {
-                msg = messages[msgKey];
+            if (messages) {
+
+                if (messages[msgPropKey]) {
+                    msg = messages[msgPropKey];
+                } else if (messages[msgKey]) {
+                    msg = messages[msgKey];
+                }
 
                 for (var p in constraint) {
                     msg = msg.replace(new RegExp('{' + p + '}', 'g'), constraint[p]);

--- a/tests/backbone-validation.js
+++ b/tests/backbone-validation.js
@@ -5,7 +5,7 @@ require(["backbone", "resthub", "jquery", "underscore", "../tests/validation/mod
     module("resthub-backbone-validation", {
         setup: function() {
             nbGetCalled = 0;
-            
+
             this.Model1 = Backbone.Model.extend({
                 className: 'org.resthub.validation.model.User',
 
@@ -35,7 +35,9 @@ require(["backbone", "resthub", "jquery", "underscore", "../tests/validation/mod
             this.Model4 = Backbone.Model.extend({
                 className: 'org.resthub.validation.model.User',
                 messages: {
-                    'validation.Min.message': 'should be greater than {value} or equals'
+                    'validation.Min.message': 'should be greater than {value} or equals',
+                    'validation.AssertTrue.message': 'must not be false',
+                    'validation.assertTrue.AssertTrue.message': 'assertTrue must be true'
                 },
 
                 initialize: _.bind(function() {
@@ -675,6 +677,18 @@ require(["backbone", "resthub", "jquery", "underscore", "../tests/validation/mod
         equal(validationErrs.minMax, "should be greater than 1 or equals", "invalid minMax should hold the correct error message");
     });
 
+    test("custom property messages", 3, function() {
+        $.get = this.mockedGet2;
+
+        var model4 = new this.Model4();
+
+        ok(!_.isEmpty(model4.validation.assertTrue), "validation should contain assertTrue");
+
+        var validationErrs = model4.validate({"assertTrue": false});
+        ok(validationErrs && validationErrs.assertTrue, "invalid assertTrue should not be valid");
+        equal(validationErrs.assertTrue, "assertTrue must be true", "invalid assertTrue should hold the correct error message");
+    });
+
     test("adding constraints", 8, function() {
         $.get = this.mockedGet2;
 
@@ -758,7 +772,7 @@ require(["backbone", "resthub", "jquery", "underscore", "../tests/validation/mod
 
         new this.Model1();
         equal(nbGetCalled, 1, "get should have been called once");
-        
+
         new this.Model1();
         equal(nbGetCalled, 1, "get should have been called once");
 


### PR DESCRIPTION
resthub-validation allows to define custom messages for constraint types per model or globally.

e.g. for a given model setting custom Min message : 

``` javascript
...
messages: {
    'validation.Min.message': 'should be greater than {value} or equals'
}
...
```

this PR adds the capacity to customize a message for a constraint type AND a property : 

e.g. for a given model AND property 'size' setting custom Min message : 

``` javascript
...
messages: {
    'validation.size.Min.message': ' size should be greater than {value} or equals'
}
...
```

The first customization option is obviously still allowed.
