### PR TITLE
fix dependency problem in tests

### DIFF
--- a/tests/backbone-populate-model.js
+++ b/tests/backbone-populate-model.js
@@ -1,4 +1,4 @@
-require(["jquery", "underscore", "backbone", "resthub", "underscore.string"], function($, _, Backbone, Resthub, _s) {
+require(["jquery", "underscore", "backbone", "resthub", "underscore-string"], function($, _, Backbone, Resthub, _s) {
 
     module("backbone-populate-model", {
         setup: function() {


### PR DESCRIPTION
populate-model tests did not run anymore because of a bad underscore-string dependency. This has been fixed
