### PR TITLE
Added Unix Epoch option for formatDate helper.

### DIFF
--- a/js/lib/resthub/handlebars-helpers.js
+++ b/js/lib/resthub/handlebars-helpers.js
@@ -178,6 +178,9 @@ define(['handlebars-orig', 'moment', 'underscore-string'], function(Handlebars, 
                 }
                 momentDate = moment(date, inputPattern);
             }
+            else if(typeof(date) === 'number') {
+                momentDate = moment(date);
+            }
             else {
                 return date;
             }


### PR DESCRIPTION
When the date provided to formatDate is a number, it is assumed to be
the unix epoch time representation.
