### PR TITLE
add prefix for views cid when property __name__ provided

### DIFF
--- a/js/lib/resthub/resthub.js
+++ b/js/lib/resthub/resthub.js
@@ -445,6 +445,13 @@ define(['underscore', 'backbone', 'jquery', 'lib/resthub/jquery-event-destroyed'
 
         strategy: 'replace',
 
+        initialize: function(options){
+            Resthub.View.__super__.initialize.apply(this);
+            if(options && options.__name__){
+                this.cid = options.__name__ + '_' + this.cid;
+            }
+        },
+
         _ensureRoot: function() {
             this.$root = this.root instanceof $ ? this.root : $(this.root);
             if (this.$root.length != 1) {

--- a/tests/backbone-populate-model.js
+++ b/tests/backbone-populate-model.js
@@ -5,9 +5,9 @@ require(["jquery", "underscore", "backbone", "resthub", "underscore-string"], fu
 
             var Person = Backbone.Model.extend({initialize: function() {
             }});
-
-            this.TestView = Resthub.View.extend({
+            var TestView = this.TestView = Resthub.View.extend({
                 initialize: function() {
+                    TestView.__super__.initialize.apply(this, arguments);
                     this.render();
                 },
 
@@ -149,6 +149,12 @@ require(["jquery", "underscore", "backbone", "resthub", "underscore-string"], fu
         testView.populateModel();
 
         ok(true, "no error");
+    });
+
+    test("View cid should contain its name", 1, function() {
+        var testView = new this.TestView({__name__:'TestView'});
+
+        ok(true, _s.startsWith( testView.cid,'TestView'));
     });
 
     test("model should be set with default values", 3, function() {


### PR DESCRIPTION
Add the possibility to prefix the cid of view to facilitate debugging. Pass the property **name** in the constructor's options.
